### PR TITLE
docs(jira-integration): update README.md MAPCO-8584

### DIFF
--- a/actions/jira-integration/README.md
+++ b/actions/jira-integration/README.md
@@ -16,7 +16,7 @@ Keep your PRs connected to Jira issues! This action validates that your pull req
 name: Jira Integration
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 
 permissions:
   statuses: write


### PR DESCRIPTION
The workflow needs the `synchronize` because on new commits, the check won't be activated